### PR TITLE
Resolve an issue when null is in an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ return function deepmerge(target, src) {
         src.forEach(function(e, i) {
             if (typeof dst[i] === 'undefined') {
                 dst[i] = e;
-            } else if (typeof e === 'object') {
+            } else if (typeof e === 'object' && e !== null) {
                 dst[i] = deepmerge(target[i], e);
             } else {
                 if (target.indexOf(e) === -1) {

--- a/test/merge.js
+++ b/test/merge.js
@@ -220,3 +220,14 @@ test('should work on arrays of nested objects', function(t) {
     t.deepEqual(merge(target, src), expected)
     t.end()
 })
+
+test('should work on array with null in it', function(t) {
+    var target = []
+
+    var src = [null]
+
+    var expected = [null]
+
+    t.deepEqual(merge(target, src), expected)
+    t.end()
+})


### PR DESCRIPTION
So, I found that the typeof null is an object. So, when null exists in an array it wants to attempt a merge on it. Well, then Object.keys(null) bombs out. This resolves the issue :smile: 