### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
   "dependencies": {},
   "devDependencies": {
     "tap": "~0.4.8"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
`npm@2.10.0` spits out warnings if package has no `license` field in package.json