### PR TITLE
Added the ability to specify `concat` array merge strategy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ methods
 
 var merge = require('deepmerge')
 
-merge(x, y)
+merge(x, y, opts)
 -----------
 
 Merge two objects `x` and `y` deeply, returning a new merged object with the
@@ -44,6 +44,13 @@ If an element at the same key is present for both `x` and `y`, the value from
 The merge is immutable, so neither `x` nor `y` will be modified.
 
 The merge will also merge arrays and array values.
+
+### options
+
+#### arrays
+
+* `merge` (default) - Replace array values at index. e.g. [1, 2] + [3] => [3, 2]
+* `concat` - Push value to the bottom of the array. e.g. [1, 2] + [3] => [1, 2, 3]
 
 install
 =======

--- a/README.markdown
+++ b/README.markdown
@@ -49,8 +49,8 @@ The merge will also merge arrays and array values.
 
 #### arrays
 
-* `merge` (default) - Replace array values at index. e.g. [1, 2] + [3] => [3, 2]
-* `concat` - Push value to the bottom of the array. e.g. [1, 2] + [3] => [1, 2, 3]
+* `merge` (default) - Replace array values at index. e.g. `[1, 2] + [3] => [3, 2]`
+* `concat` - Push value to the bottom of the array. e.g. `[1, 2] + [3] => [1, 2, 3]`
 
 install
 =======

--- a/README.markdown
+++ b/README.markdown
@@ -47,7 +47,7 @@ The merge will also merge arrays and array values.
 
 ### options
 
-#### arrays
+**arrays**
 
 * `merge` (default) - Replace array values at index. e.g. `[1, 2] + [3] => [3, 2]`
 * `concat` - Push value to the bottom of the array. e.g. `[1, 2] + [3] => [1, 2, 3]`

--- a/index.js
+++ b/index.js
@@ -8,21 +8,27 @@
     }
 }(this, function () {
 
-return function deepmerge(target, src) {
+return function deepmerge(target, src, opts) {
     var array = Array.isArray(src);
     var dst = array && [] || {};
+    opts = opts || {};
 
     if (array) {
         target = target || [];
         dst = dst.concat(target);
+
         src.forEach(function(e, i) {
-            if (typeof dst[i] === 'undefined') {
-                dst[i] = e;
-            } else if (typeof e === 'object') {
-                dst[i] = deepmerge(target[i], e);
+            if (opts.arrays === 'concat') {
+                dst.push(e);
             } else {
-                if (target.indexOf(e) === -1) {
-                    dst.push(e);
+                if (typeof dst[i] === 'undefined') {
+                    dst[i] = e;
+                } else if (typeof e === 'object') {
+                    dst[i] = deepmerge(target[i], e, opts);
+                } else {
+                    if (target.indexOf(e) === -1) {
+                        dst.push(e);
+                    }
                 }
             }
         });
@@ -40,7 +46,7 @@ return function deepmerge(target, src) {
                 if (!target[key]) {
                     dst[key] = src[key];
                 } else {
-                    dst[key] = deepmerge(target[key], src[key]);
+                    dst[key] = deepmerge(target[key], src[key], opts);
                 }
             }
         });

--- a/test/merge.js
+++ b/test/merge.js
@@ -220,3 +220,23 @@ test('should work on arrays of nested objects', function(t) {
     t.deepEqual(merge(target, src), expected)
     t.end()
 })
+
+test('should push src to target if arrays opts is concat', function(t) {
+    var target = [
+        { key1: { subkey: 'one' } }
+    ]
+
+    var src = [
+        { key1: { subkey: 'two' } },
+        { key2: { subkey: 'three' } }
+    ]
+
+    var expected = [
+        { key1: { subkey: 'one' } },
+        { key1: { subkey: 'two' } },
+        { key2: {subkey: 'three' } }
+    ]
+
+    t.deepEqual(merge(target, src, { arrays: 'concat' }), expected)
+    t.end()
+})


### PR DESCRIPTION
Merge arrays by pushing src to target.

e.g. `[1, 2] + [3] => [1, 2, 3]`