### PR TITLE
Add ability to specify merge behavior of arrays

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,18 +32,29 @@ methods
 
 var merge = require('deepmerge')
 
-merge(x, y)
+merge(target, source[, options])
 -----------
 
-Merge two objects `x` and `y` deeply, returning a new merged object with the
-elements from both `x` and `y`.
+Merge two objects `target` and `source` deeply, returning a new merged object with the
+elements from both `target` and `source`.
 
-If an element at the same key is present for both `x` and `y`, the value from
-`y` will appear in the result.
+If an element at the same key is present for both `target` and `source`, the value from
+`source` will appear in the result.
 
-The merge is immutable, so neither `x` nor `y` will be modified.
+The merge is immutable, so neither `target` nor `source` will be modified.
 
 The merge will also merge arrays and array values.
+
+options
+=======
+
+`options` is an optional parameter.
+
+```js
+options: {
+  array: 'both' // to specify the behavior of array merging, possible values (both, target, source)
+}
+```
 
 install
 =======

--- a/index.js
+++ b/index.js
@@ -8,20 +8,49 @@
     }
 }(this, function () {
 
-return function deepmerge(target, src) {
+/**
+ * To set the default values of options if not passed
+ * 
+ * @param {Object|Undefuned} options
+ * @return {Object}
+ */
+function setDefaultOptions(options) {
+
+    if (typeof options === 'undefined') {
+        options = {};
+    }
+
+    // Merge arrays, posibble values (both, target, source)
+    if (typeof options.array === 'undefined') {
+        options.array = 'both';
+    }
+
+    return options;
+  
+}
+
+return function deepmerge(target, src, options) {
+
+    // To set the default values of options if not passed
+    options = setDefaultOptions(options);
+
     var array = Array.isArray(src);
     var dst = array && [] || {};
 
     if (array) {
         target = target || [];
-        dst = dst.concat(target);
+        // Include target's array elements
+        if (options.array === 'both' || options.array === 'target') {
+            dst = dst.concat(target);
+        }
         src.forEach(function(e, i) {
             if (typeof dst[i] === 'undefined') {
                 dst[i] = e;
             } else if (typeof e === 'object') {
-                dst[i] = deepmerge(target[i], e);
+                dst[i] = deepmerge(target[i], e, options);
             } else {
-                if (target.indexOf(e) === -1) {
+                if (target.indexOf(e) === -1 &&
+                   (options.array === 'both' || options.array === 'source')) {
                     dst.push(e);
                 }
             }
@@ -40,7 +69,7 @@ return function deepmerge(target, src) {
                 if (!target[key]) {
                     dst[key] = src[key];
                 } else {
-                    dst[key] = deepmerge(target[key], src[key]);
+                    dst[key] = deepmerge(target[key], src[key], options);
                 }
             }
         });


### PR DESCRIPTION
Sample

```js
var deepmerge = require('deepmerge');

var target = {
  name: 'Fares',
  age: 44,
  favColors: ['red', 'blue', 'green']
};

var source = {
  name: 'Fares',
  age: 44,
  favColors: ['pink', 'yellow', 'white']
};

// Default behavior
var both = deepmerge(target, source, {
  // to specify the behavior of array merging (both, target, source)
  array: 'both'
});

// Include the arrays elements of the target
var target = deepmerge(target, source, {
  array: 'target'
});

// Include the arrays elements of the source
var source = deepmerge(target, source, {
  array: 'source'
});

console.log(JSON.stringify(both, null, 2));
console.log(JSON.stringify(target, null, 2));
console.log(JSON.stringify(source, null, 2));
```

Output

```js
{
  "name": "Fares",
  "age": 44,
  "favColors": [
    "red",
    "blue",
    "green",
    "pink",
    "yellow",
    "white"
  ]
}
{
  "name": "Fares",
  "age": 44,
  "favColors": [
    "red",
    "blue",
    "green"
  ]
}
{
  "name": "Fares",
  "age": 44,
  "favColors": [
    "pink",
    "yellow",
    "white"
  ]
}
```