### PR TITLE
Handle edge case where Arrays and Objects are merged

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ return function deepmerge(target, src) {
     var dst = array && [] || {};
 
     if (array) {
-        target = target || [];
+        target = target instanceof Array ? target :  [];
         dst = dst.concat(target);
         src.forEach(function(e, i) {
             if (typeof dst[i] === 'undefined') {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ return function deepmerge(target, src) {
     var dst = array && [] || {};
 
     if (array) {
-        target = target instanceof Array ? target :  [];
+        target = Array.isArray(target) ? target :  [];
         dst = dst.concat(target);
         src.forEach(function(e, i) {
             if (typeof dst[i] === 'undefined') {

--- a/test/merge.js
+++ b/test/merge.js
@@ -129,6 +129,23 @@ test('should replace object with simple key in target', function (t) {
     t.end()
 })
 
+test('should replace objects with arrays', function(t) {
+    var target = [
+        { key1: { subkey: 'one' }}
+    ]
+
+    var src = [
+        { key1: [ "subkey" ]}
+    ]
+
+    var expected = [
+        { key1: [ "subkey" ]}
+    ]
+
+    t.deepEqual(merge(target, src), expected)
+    t.end()
+})
+
 test('should work on simple array', function (t) {
     var src = ['one', 'three']
     var target = ['one', 'two']


### PR DESCRIPTION
Handle edge case where the library attempts to merge an array and an object.
```
merge({foo: {bar: true}}, {foo: ["bar"]})
```
This fix simply replaces the object with the array that is now at the objects location.