### PR TITLE
Custom array merging

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ methods
 var merge = require('deepmerge')
 ```
 
-merge(x, y)
+merge(x, y, [options])
 -----------
 
 Merge two objects `x` and `y` deeply, returning a new merged object with the
@@ -42,7 +42,14 @@ If an element at the same key is present for both `x` and `y`, the value from
 
 The merge is immutable, so neither `x` nor `y` will be modified.
 
-The merge will also merge arrays and array values.
+The merge will also merge arrays and array values by default.  However, there are nigh-infinite valid ways to merge arrays, and you may want to supply your own.  You can do this by passing an `arrayMerge` function as an option.
+
+```js
+function concatMerge(destinationArray, sourceArray, mergeOptions) {
+	return destinationArray.concat(sourceArray)
+}
+merge([1, 2, 3], [1, 2, 3], { arrayMerge: concatMerge }) // => [1, 2, 3, 1, 2, 3]
+```
 
 install
 =======

--- a/index.js
+++ b/index.js
@@ -16,42 +16,38 @@ function isMergeableObject(val) {
         && Object.prototype.toString.call(val) !== '[object Date]'
 }
 
-return function deepmerge(target, src) {
-    var array = Array.isArray(src);
-    var dst = array ? [] : {};
+return function deepmerge(target, source) {
+    var array = Array.isArray(source);
+    var destination = array ? [] : {};
 
     if (array) {
         target = target || [];
-        dst = dst.concat(target);
-        src.forEach(function(e, i) {
-            if (typeof dst[i] === 'undefined') {
-                dst[i] = e;
+        destination = destination.concat(target);
+        source.forEach(function(e, i) {
+            if (typeof destination[i] === 'undefined') {
+                destination[i] = e;
             } else if (isMergeableObject(e)) {
-                dst[i] = deepmerge(target[i], e);
+                destination[i] = deepmerge(target[i], e);
             } else if (target.indexOf(e) === -1) {
-                dst.push(e);
+                destination.push(e);
             }
         });
     } else {
         if (isMergeableObject(target)) {
             Object.keys(target).forEach(function (key) {
-                dst[key] = target[key];
+                destination[key] = target[key];
             })
         }
-        Object.keys(src).forEach(function (key) {
-            if (!isMergeableObject(src[key])) {
-                dst[key] = src[key];
+        Object.keys(source).forEach(function (key) {
+            if (!isMergeableObject(source[key]) || !target[key]) {
+                destination[key] = source[key];
             } else {
-                if (!target[key]) {
-                    dst[key] = src[key];
-                } else {
-                    dst[key] = deepmerge(target[key], src[key]);
-                }
+                destination[key] = deepmerge(target[key], source[key]);
             }
         });
     }
 
-    return dst;
+    return destination;
 }
 
 }));

--- a/test/custom-array-merge.js
+++ b/test/custom-array-merge.js
@@ -1,0 +1,44 @@
+var merge = require('../')
+var test = require('tap').test
+
+test('custom merge array', function(t) {
+	var mergeFunctionCalled = false
+	function concatMerge(target, source, options) {
+		t.notOk(mergeFunctionCalled)
+		mergeFunctionCalled = true
+
+		t.deepEqual(target, [1, 2])
+		t.deepEqual(source, [1, 2, 3])
+		t.equal(options.arrayMerge, concatMerge)
+
+		return target.concat(source)
+	}
+	const destination = {
+		someArray: [1, 2],
+		someObject: { what: 'yes' }
+	}
+	const source = {
+		someArray: [1, 2, 3]
+	}
+
+	const actual = merge(destination, source, { arrayMerge: concatMerge })
+	const expected = {
+		someArray: [1, 2, 1, 2, 3],
+		someObject: { what: 'yes' }
+	}
+
+	t.ok(mergeFunctionCalled)
+	t.deepEqual(actual, expected)
+	t.end()
+})
+
+test('merge top-level arrays', function(t) {
+	function concatMerge(a, b) {
+		return a.concat(b)
+	}
+	var actual = merge([1, 2], [1, 2], { arrayMerge: concatMerge })
+	var expected = [1, 2, 1, 2]
+
+	t.deepEqual(actual, expected)
+	t.end()
+})


### PR DESCRIPTION
A potential fix for #14, #20, #21, #22, #24, #32.

The default merge strategy is exactly the same as it was before (though I'm suspicious of that falsey target property check on line 41 - that can be dealt with as a separate issue if need be).

You can implement whatever other array-merging strategy you like - the merge function is passed both arrays, plus the original options passed to `deepmerge`.

Any thoughts?  Is this a good general solution?  I didn't want to add complexity while solving this common issue.

I did a bit of refactoring in the first commit of this pull request, mostly to get rid of abbreviated variable names.