### PR TITLE
Added tests case for {a:[]} {a:undefined}

### DIFF
--- a/test/merge.js
+++ b/test/merge.js
@@ -263,6 +263,21 @@ test('should work on array with null in it', function(t) {
     t.end()
 })
 
+test('should overwrite values when property is initialised but undefined', function(t) {
+    var target1 = { value: [] }
+    var target2 = { value: null }
+    var target3 = { value: 2 }
+
+    var src = { value: undefined }
+
+    var expected = { value: undefined }
+
+    t.deepEqual(merge(target1, src), expected)
+    t.deepEqual(merge(target2, src), expected)
+    t.deepEqual(merge(target3, src), expected)
+    t.end()
+})
+
 test('null should be equal to null in an array', function(t) {
     var target = [null, 'dude']
     var source = [null, 'lol']


### PR DESCRIPTION
Hello! Currently in the process of moving away from lodash, looking to use this library for deep merging.

Currently, if you merge `{ array: [] }` and `{ array: undefined }`, you get `{ array: null }`. This seems… odd.

My preferred behaviour would be for the result to be `{ array: [] }` - this is how `lodash/merge` behaves - but at the very least it should probably by `{ array: undefined }`.

Thoughts? Happy to add a fix to this PR, whatever is decided.