### PR TITLE
Add option to clone objects before merge. Fixes #28 issue.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,8 @@ If an element at the same key is present for both `x` and `y`, the value from
 
 The merge is immutable, so neither `x` nor `y` will be modified.
 
+#### option: arrayMerge
+
 The merge will also merge arrays and array values by default.  However, there are nigh-infinite valid ways to merge arrays, and you may want to supply your own.  You can do this by passing an `arrayMerge` function as an option.
 
 ```js
@@ -51,6 +53,9 @@ function concatMerge(destinationArray, sourceArray, mergeOptions) {
 merge([1, 2, 3], [1, 2, 3], { arrayMerge: concatMerge }) // => [1, 2, 3, 1, 2, 3]
 ```
 
+#### option: clone
+
+If `clone` option is `true` then both `x` and `y` would be clonned before merge. Default value for `clone` is `false`. 
 install
 =======
 

--- a/index.js
+++ b/index.js
@@ -18,12 +18,17 @@ function isMergeableObject(val) {
 
 function defaultArrayMerge(target, source, optionsArgument) {
     var destination = target.slice()
+    var clone = optionsArgument && optionsArgument.clone === true
     source.forEach(function(e, i) {
         if (typeof destination[i] === 'undefined') {
             destination[i] = e
         } else if (isMergeableObject(e)) {
             destination[i] = deepmerge(target[i], e, optionsArgument)
         } else if (target.indexOf(e) === -1) {
+            if (clone && isMergeableObject(e)) {
+                var emptyTarget = Array.isArray(e) ? [] : {}  
+                e = deepmerge(emptyTarget, e)
+            }
             destination.push(e)
         }
     })
@@ -31,22 +36,25 @@ function defaultArrayMerge(target, source, optionsArgument) {
 }
 
 function mergeObject(target, source, optionsArgument) {
-    var clone = optionsArgument && optionsArgument.hasOwnProperty('clone') 
-        ? optionsArgument.clone : false
+    var clone = optionsArgument && optionsArgument.clone === true
     var destination = {}
     if (isMergeableObject(target)) {
         Object.keys(target).forEach(function (key) {
             var val = target[key]
-            if (clone && typeof val === 'object') 
-                val = deepmerge({}, val) 
+            if (clone && isMergeableObject(val)) {
+                var emptyTarget = Array.isArray(val) ? [] : {}  
+                val = deepmerge(emptyTarget, val) 
+            }
             destination[key] = val
         })
     }
     Object.keys(source).forEach(function (key) {
         if (!isMergeableObject(source[key]) || !target[key]) {
             var val = source[key]
-            if (clone && typeof val === 'object') 
-                val = deepmerge({}, val) 
+            if (clone && isMergeableObject(val)) {
+                var emptyTarget = Array.isArray(val) ? [] : {}  
+                val = deepmerge(emptyTarget, val) 
+            }
             destination[key] = val
         } else {
             destination[key] = deepmerge(target[key], source[key], optionsArgument)

--- a/index.js
+++ b/index.js
@@ -31,15 +31,23 @@ function defaultArrayMerge(target, source, optionsArgument) {
 }
 
 function mergeObject(target, source, optionsArgument) {
+    var clone = optionsArgument && optionsArgument.hasOwnProperty('clone') 
+        ? optionsArgument.clone : false
     var destination = {}
     if (isMergeableObject(target)) {
         Object.keys(target).forEach(function (key) {
-            destination[key] = target[key]
+            var val = target[key]
+            if (clone && typeof val === 'object') 
+                val = deepmerge({}, val) 
+            destination[key] = val
         })
     }
     Object.keys(source).forEach(function (key) {
         if (!isMergeableObject(source[key]) || !target[key]) {
-            destination[key] = source[key]
+            var val = source[key]
+            if (clone && typeof val === 'object') 
+                val = deepmerge({}, val) 
+            destination[key] = val
         } else {
             destination[key] = deepmerge(target[key], source[key], optionsArgument)
         }

--- a/index.js
+++ b/index.js
@@ -16,18 +16,24 @@ function isMergeableObject(val) {
         && Object.prototype.toString.call(val) !== '[object Date]'
 }
 
+function emptyTarget(val) {
+    return Array.isArray(val) ? [] : {}
+}
+
 function defaultArrayMerge(target, source, optionsArgument) {
     var destination = target.slice()
     var clone = optionsArgument && optionsArgument.clone === true
     source.forEach(function(e, i) {
         if (typeof destination[i] === 'undefined') {
+            if (clone && isMergeableObject(e)) {
+                e = deepmerge(emptyTarget(e), e)
+            }
             destination[i] = e
         } else if (isMergeableObject(e)) {
             destination[i] = deepmerge(target[i], e, optionsArgument)
         } else if (target.indexOf(e) === -1) {
             if (clone && isMergeableObject(e)) {
-                var emptyTarget = Array.isArray(e) ? [] : {}  
-                e = deepmerge(emptyTarget, e)
+                e = deepmerge(emptyTarget(e), e)
             }
             destination.push(e)
         }
@@ -42,8 +48,7 @@ function mergeObject(target, source, optionsArgument) {
         Object.keys(target).forEach(function (key) {
             var val = target[key]
             if (clone && isMergeableObject(val)) {
-                var emptyTarget = Array.isArray(val) ? [] : {}  
-                val = deepmerge(emptyTarget, val) 
+                val = deepmerge(emptyTarget(val), val)
             }
             destination[key] = val
         })
@@ -52,8 +57,7 @@ function mergeObject(target, source, optionsArgument) {
         if (!isMergeableObject(source[key]) || !target[key]) {
             var val = source[key]
             if (clone && isMergeableObject(val)) {
-                var emptyTarget = Array.isArray(val) ? [] : {}  
-                val = deepmerge(emptyTarget, val) 
+                val = deepmerge(emptyTarget(val), val)
             }
             destination[key] = val
         } else {

--- a/test/merge.js
+++ b/test/merge.js
@@ -106,6 +106,61 @@ test('should add nested object in target', function(t) {
     t.end()
 })
 
+test('should clone source and target', function(t) {
+    var src = {
+        "b": {
+            "c": "foo"
+        }
+    }
+
+    var target = {
+        "a": {
+            "d": "bar"
+        }
+    }
+
+    var merged = merge(target, src,{clone:true})
+     
+    merged.b.c = "foo-modified"
+    merged.a.d = "bar-modifies"
+    t.equal(src.b.c, "foo") 
+    t.equal(target.a.d, "bar") 
+
+    t.end()
+})
+
+test('should not clone source and target', function(t) {
+    var src = {
+        "b": {
+            "c": "foo"
+        }
+    }
+
+    var target = {
+        "a": {
+            "d": "bar"
+        }
+    }
+
+    var expected = {
+        "a": {
+            "d": "bar"
+        },
+        "b": {
+            "c": "_foo"
+        }
+    }
+    
+    var merged = merge(target, src)
+    
+    merged.b.c = "foo-modified"
+    merged.a.d = "bar-modified"
+    t.equal(src.b.c, "foo-modified") 
+    t.equal(target.a.d, "bar-modified") 
+
+    t.end()
+})
+
 test('should replace object with simple key in target', function (t) {
     var src = { key1: 'value1' }
     var target = {

--- a/test/merge.js
+++ b/test/merge.js
@@ -119,12 +119,21 @@ test('should clone source and target', function(t) {
         }
     }
 
-    var merged = merge(target, src,{clone:true})
-     
-    merged.b.c = "foo-modified"
-    merged.a.d = "bar-modifies"
-    t.equal(src.b.c, "foo") 
-    t.equal(target.a.d, "bar") 
+    var expected = {
+        "a": {
+            "d": "bar"
+        },
+        "b": {
+            "c": "foo"
+        }
+    }
+
+    var merged = merge(target, src, {clone: true})
+    
+    t.deepEqual(merged, expected)
+    
+    t.notEqual(merged.a, target.a) 
+    t.notEqual(merged.b, src.b) 
 
     t.end()
 })
@@ -147,16 +156,13 @@ test('should not clone source and target', function(t) {
             "d": "bar"
         },
         "b": {
-            "c": "_foo"
+            "c": "foo"
         }
     }
     
     var merged = merge(target, src)
-    
-    merged.b.c = "foo-modified"
-    merged.a.d = "bar-modified"
-    t.equal(src.b.c, "foo-modified") 
-    t.equal(target.a.d, "bar-modified") 
+    t.equal(merged.a, target.a) 
+    t.equal(merged.b, src.b) 
 
     t.end()
 })
@@ -231,6 +237,33 @@ test('should work on array properties', function (t) {
     t.end()
 })
 
+test('should work on array properties with clone option', function (t) {
+    var src = {
+        key1: ['one', 'three'],
+        key2: ['four']
+    }
+    var target = {
+        key1: ['one', 'two']
+    }
+
+    var expected = {
+        key1: ['one', 'two', 'three'],
+        key2: ['four']
+    }
+
+    t.deepEqual(target, {
+        key1: ['one', 'two']
+    })
+    var merged = merge(target, src, {clone: true})
+    t.deepEqual(merged, expected)
+    t.ok(Array.isArray(merge(target, src).key1))
+    t.ok(Array.isArray(merge(target, src).key2))
+    t.notEqual(merged.key1, src.key1) 
+    t.notEqual(merged.key1, target.key1) 
+    t.notEqual(merged.key2, src.key2) 
+    t.end()
+})
+
 test('should work on array of objects', function (t) {
     var src = [
         { key1: ['one', 'three'], key2: ['one'] },
@@ -254,6 +287,37 @@ test('should work on array of objects', function (t) {
     t.ok(Array.isArray(merge(target, src)), 'result should be an array')
     t.ok(Array.isArray(merge(target, src)[0].key1), 'subkey should be an array too')
 
+    t.end()
+})
+
+test('should work on array of objects with clone option', function (t) {
+    var src = [
+        { key1: ['one', 'three'], key2: ['one'] },
+        { key3: ['five'] }
+    ]
+    var target = [
+        { key1: ['one', 'two'] },
+        { key3: ['four'] }
+    ]
+
+    var expected = [
+        { key1: ['one', 'two', 'three'], key2: ['one'] },
+        { key3: ['four', 'five'] }
+    ]
+
+    t.deepEqual(target, [
+        { key1: ['one', 'two'] },
+        { key3: ['four'] }
+    ])
+    var merged = merge(target, src, {clone: true}) 
+    t.deepEqual(merged, expected)
+    t.ok(Array.isArray(merge(target, src)), 'result should be an array')
+    t.ok(Array.isArray(merge(target, src)[0].key1), 'subkey should be an array too')
+    t.notEqual(merged[0].key1, src[0].key1)
+    t.notEqual(merged[0].key1, target[0].key1)
+    t.notEqual(merged[0].key2, src[0].key2)
+    t.notEqual(merged[1].key3, src[1].key3)
+    t.notEqual(merged[1].key3, target[1].key3)
     t.end()
 })
 
@@ -286,6 +350,18 @@ test('should treat regular expressions like primitive values', function (t) {
     t.end()
 })
 
+test('should treat regular expressions like primitive values with clone option',
+    function (t) {
+        var target = { key1: /abc/ }
+        var src = { key1: /efg/ }
+        var expected = { key1: /efg/ }
+    
+        t.deepEqual(merge(target, src, {clone: true}), expected)
+        t.deepEqual(merge(target, src, {clone: true}).key1.test('efg'), true)
+        t.end()
+    }
+)
+
 test('should treat dates like primitives', function(t) {
     var monday = new Date('2016-09-27T01:08:12.761Z')
     var tuesday = new Date('2016-09-28T01:18:12.761Z')
@@ -301,6 +377,27 @@ test('should treat dates like primitives', function(t) {
         key: tuesday
     }
     var actual = merge(target, source)
+
+    t.deepEqual(actual, expected)
+    t.equal(actual.key.valueOf(), tuesday.valueOf())
+    t.end()
+})
+
+test('should treat dates like primitives with clone option', function(t) {
+    var monday = new Date('2016-09-27T01:08:12.761Z')
+    var tuesday = new Date('2016-09-28T01:18:12.761Z')
+
+    var target = {
+        key: monday
+    }
+    var source = {
+        key: tuesday
+    }
+
+    var expected = {
+        key: tuesday
+    }
+    var actual = merge(target, source, {clone: true})
 
     t.deepEqual(actual, expected)
     t.equal(actual.key.valueOf(), tuesday.valueOf())

--- a/test/merge.js
+++ b/test/merge.js
@@ -129,11 +129,11 @@ test('should clone source and target', function(t) {
     }
 
     var merged = merge(target, src, {clone: true})
-    
+
     t.deepEqual(merged, expected)
-    
-    t.notEqual(merged.a, target.a) 
-    t.notEqual(merged.b, src.b) 
+
+    t.notEqual(merged.a, target.a)
+    t.notEqual(merged.b, src.b)
 
     t.end()
 })
@@ -159,10 +159,10 @@ test('should not clone source and target', function(t) {
             "c": "foo"
         }
     }
-    
+
     var merged = merge(target, src)
-    t.equal(merged.a, target.a) 
-    t.equal(merged.b, src.b) 
+    t.equal(merged.a, target.a)
+    t.equal(merged.b, src.b)
 
     t.end()
 })
@@ -255,12 +255,9 @@ test('should work on array properties with clone option', function (t) {
         key1: ['one', 'two']
     })
     var merged = merge(target, src, {clone: true})
-    t.deepEqual(merged, expected)
-    t.ok(Array.isArray(merge(target, src).key1))
-    t.ok(Array.isArray(merge(target, src).key2))
-    t.notEqual(merged.key1, src.key1) 
-    t.notEqual(merged.key1, target.key1) 
-    t.notEqual(merged.key2, src.key2) 
+    t.notEqual(merged.key1, src.key1)
+    t.notEqual(merged.key1, target.key1)
+    t.notEqual(merged.key2, src.key2)
     t.end()
 })
 
@@ -309,7 +306,7 @@ test('should work on array of objects with clone option', function (t) {
         { key1: ['one', 'two'] },
         { key3: ['four'] }
     ])
-    var merged = merge(target, src, {clone: true}) 
+    var merged = merge(target, src, {clone: true})
     t.deepEqual(merged, expected)
     t.ok(Array.isArray(merge(target, src)), 'result should be an array')
     t.ok(Array.isArray(merge(target, src)[0].key1), 'subkey should be an array too')
@@ -350,14 +347,16 @@ test('should treat regular expressions like primitive values', function (t) {
     t.end()
 })
 
-test('should treat regular expressions like primitive values with clone option',
+test('should treat regular expressions like primitive values and should not'
+    + ' clone even with clone option',
     function (t) {
         var target = { key1: /abc/ }
         var src = { key1: /efg/ }
         var expected = { key1: /efg/ }
-    
-        t.deepEqual(merge(target, src, {clone: true}), expected)
-        t.deepEqual(merge(target, src, {clone: true}).key1.test('efg'), true)
+
+        var output = merge(target, src, {clone: true})
+
+        t.equal(output.key1, src.key1)
         t.end()
     }
 )
@@ -383,7 +382,8 @@ test('should treat dates like primitives', function(t) {
     t.end()
 })
 
-test('should treat dates like primitives with clone option', function(t) {
+test('should treat dates like primitives and should not clone even with clone'
+    +  ' option', function(t) {
     var monday = new Date('2016-09-27T01:08:12.761Z')
     var tuesday = new Date('2016-09-28T01:18:12.761Z')
 
@@ -399,8 +399,7 @@ test('should treat dates like primitives with clone option', function(t) {
     }
     var actual = merge(target, source, {clone: true})
 
-    t.deepEqual(actual, expected)
-    t.equal(actual.key.valueOf(), tuesday.valueOf())
+    t.equal(actual.key, tuesday)
     t.end()
 })
 
@@ -415,6 +414,18 @@ test('should work on array with null in it', function(t) {
     t.end()
 })
 
+test('should clone array\'s element if it is object', function(t) {
+    var a = { key: 'yup' }
+    var target = []
+    var source = [a]
+    var expected = [{key: 'yup'}]
+
+    var output = merge(target, source, {clone: true})
+
+    t.notEqual(output[0], a)
+    t.equal(output[0].key, 'yup')
+    t.end()
+})
 test('should overwrite values when property is initialised but undefined', function(t) {
     var target1 = { value: [] }
     var target2 = { value: null }


### PR DESCRIPTION
Added option `clone` as boolean to clone objects before merge. Fixes #28 issue.