### PR TITLE
Merge arrays onto objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,7 @@ function deepmerge(target, source, optionsArgument) {
     var arrayMerge = options.arrayMerge || defaultArrayMerge
 
     if (array) {
-        target = target || [];
-        return arrayMerge(target, source, optionsArgument)
+        return Array.isArray(target) ? arrayMerge(target, source, optionsArgument) : source.slice()
     } else {
         return mergeObject(target, source, optionsArgument)
     }

--- a/test/merge.js
+++ b/test/merge.js
@@ -129,6 +129,23 @@ test('should replace object with simple key in target', function (t) {
     t.end()
 })
 
+test('should replace objects with arrays', function(t) {
+    var target = [
+        { key1: { subkey: 'one' }}
+    ]
+
+    var src = [
+        { key1: [ "subkey" ]}
+    ]
+
+    var expected = [
+        { key1: [ "subkey" ]}
+    ]
+
+    t.deepEqual(merge(target, src), expected)
+    t.end()
+})
+
 test('should work on simple array', function (t) {
     var src = ['one', 'three']
     var target = ['one', 'two']

--- a/test/merge.js
+++ b/test/merge.js
@@ -146,6 +146,40 @@ test('should replace objects with arrays', function(t) {
     t.end()
 })
 
+test('should replace dates with arrays', function(t) {
+    var target = [
+        { key1: new Date()}
+    ]
+
+    var src = [
+        { key1: [ "subkey" ]}
+    ]
+
+    var expected = [
+        { key1: [ "subkey" ]}
+    ]
+
+    t.deepEqual(merge(target, src), expected)
+    t.end()
+})
+
+test('should replace null with arrays', function(t) {
+    var target = {
+        key1: null
+    }
+
+    var src = {
+        key1: [ "subkey" ]
+    }
+
+    var expected = {
+        key1: [ "subkey" ]
+    }
+
+    t.deepEqual(merge(target, src), expected)
+    t.end()
+})
+
 test('should work on simple array', function (t) {
     var src = ['one', 'three']
     var target = ['one', 'two']


### PR DESCRIPTION
Fixes a crash in the current version.  Would be published as a patch release.

There's a merge conflict on #36, so I grabbed @macdja38's test and added the post-#37-fix.

Look reasonable to everyone?