### PR TITLE
Small refactor + bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,46 +20,35 @@ function emptyTarget(val) {
     return Array.isArray(val) ? [] : {}
 }
 
+function cloneIfNecessary(value, optionsArgument) {
+    var clone = optionsArgument && optionsArgument.clone === true
+    return (clone && isMergeableObject(value)) ? deepmerge(emptyTarget(value), value) : value
+}
+
 function defaultArrayMerge(target, source, optionsArgument) {
     var destination = target.slice()
-    var clone = optionsArgument && optionsArgument.clone === true
     source.forEach(function(e, i) {
         if (typeof destination[i] === 'undefined') {
-            if (clone && isMergeableObject(e)) {
-                e = deepmerge(emptyTarget(e), e)
-            }
-            destination[i] = e
+            destination[i] = cloneIfNecessary(e, optionsArgument)
         } else if (isMergeableObject(e)) {
             destination[i] = deepmerge(target[i], e, optionsArgument)
         } else if (target.indexOf(e) === -1) {
-            if (clone && isMergeableObject(e)) {
-                e = deepmerge(emptyTarget(e), e)
-            }
-            destination.push(e)
+            destination.push(cloneIfNecessary(e, optionsArgument))
         }
     })
     return destination
 }
 
 function mergeObject(target, source, optionsArgument) {
-    var clone = optionsArgument && optionsArgument.clone === true
     var destination = {}
     if (isMergeableObject(target)) {
         Object.keys(target).forEach(function (key) {
-            var val = target[key]
-            if (clone && isMergeableObject(val)) {
-                val = deepmerge(emptyTarget(val), val)
-            }
-            destination[key] = val
+            destination[key] = cloneIfNecessary(target[key], optionsArgument)
         })
     }
     Object.keys(source).forEach(function (key) {
         if (!isMergeableObject(source[key]) || !target[key]) {
-            var val = source[key]
-            if (clone && isMergeableObject(val)) {
-                val = deepmerge(emptyTarget(val), val)
-            }
-            destination[key] = val
+            destination[key] = cloneIfNecessary(source[key], optionsArgument)
         } else {
             destination[key] = deepmerge(target[key], source[key], optionsArgument)
         }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function emptyTarget(val) {
 
 function cloneIfNecessary(value, optionsArgument) {
     var clone = optionsArgument && optionsArgument.clone === true
-    return (clone && isMergeableObject(value)) ? deepmerge(emptyTarget(value), value) : value
+    return (clone && isMergeableObject(value)) ? deepmerge(emptyTarget(value), value, optionsArgument) : value
 }
 
 function defaultArrayMerge(target, source, optionsArgument) {
@@ -62,7 +62,7 @@ function deepmerge(target, source, optionsArgument) {
     var arrayMerge = options.arrayMerge || defaultArrayMerge
 
     if (array) {
-        return Array.isArray(target) ? arrayMerge(target, source, optionsArgument) : source.slice()
+        return Array.isArray(target) ? arrayMerge(target, source, optionsArgument) : cloneIfNecessary(source, optionsArgument)
     } else {
         return mergeObject(target, source, optionsArgument)
     }

--- a/test/merge.js
+++ b/test/merge.js
@@ -477,6 +477,18 @@ test('should clone array\'s element if it is object', function(t) {
     t.equal(output[0].key, 'yup')
     t.end()
 })
+
+test('should clone an array property when there is no target array', function(t) {
+    const someObject = {}
+    var target = {}
+    var source = { ary: [someObject]}
+    var output = merge(target, source, { clone: true })
+
+    t.deepEqual(output, { ary: [{}] })
+    t.notEqual(output.ary[0], someObject)
+    t.end()
+})
+
 test('should overwrite values when property is initialised but undefined', function(t) {
     var target1 = { value: [] }
     var target2 = { value: null }


### PR DESCRIPTION
- Refactored
```js
if (clone && isMergeableObject(e)) {
  e = deepmerge(emptyTarget(e), e)
}
```
into a `cloneIfNecessary` function.

- Added a test for the shallow array copy issue noted over at https://github.com/KyleAMathews/deepmerge/pull/44#issuecomment-253238515
- Fixed the shallow array copy

This also fixes a bug where the `deepmerge` clone calls weren't being passed the `clone` option (or any other options).