### PR TITLE
Added typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+declare namespace deepmerge {
+    interface DeepmergeSignature {
+        <T>(x: T, y: T, options?: DeepmergeOptions<T>): T;
+        all: <T>(objects: T[], options?: DeepmergeOptions<T>) => T;
+    }
+
+    interface DeepmergeOptions<T> {
+        clone?: boolean;
+        arrayMerge?: (destination: T, source: T, options?: DeepmergeOptions<T>) => T;
+    }
+}
+
+declare let deepmerge: deepmerge.DeepmergeSignature;
+
+declare module 'deepmerge' {
+    export = deepmerge;
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "type": "git",
     "url": "git://github.com/KyleAMathews/deepmerge.git"
   },
-  "main": "index",
+  "main": "index.js",
+  "types": "index.d.ts",
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
I've added some typings for deepmerge that can be included. 

With this, deepmerge can be used in typescript without hassle like this: 

```typescript
import * as merge from 'deepmerge';
```