### PR TITLE
README: add info about source code file size

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,8 @@
 deepmerge
 =========
 
+> ~550B gzipped, ~1.0kB minified
+
 Merge the enumerable attributes of two objects deeply.
 
 example


### PR DESCRIPTION
I tend to look for these metrics when evaluating packages, this makes it readily available.  ¯\\\_(ツ)_/¯

```sh
$ npm install uglify-js
$ ./node_modules/.bin/uglifyjs --compress --mangle -- index.js | wc -c
1076
$ ./node_modules/.bin/uglifyjs --compress --mangle -- index.js | gzip -c | wc -c
533
```