### PR TITLE
Turning on the new C++ compiler in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ node_js:
   - "8"
   - "6"
   - "4"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
Trying to get JSMD tests to pass on node 8

As per https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements