### PR TITLE
Move is-mergeable-object from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "build": "rollup -c",
     "test": "npm run build && tap test/*.js && jsmd readme.md"
   },
-  "devDependencies": {
+  "dependencies": {
     "is-mergeable-object": "1.1.0",
+  },
+  "devDependencies": {
     "jsmd": "0.3.1",
     "rollup": "0.49.3",
     "rollup-plugin-commonjs": "8.2.1",


### PR DESCRIPTION
`deepmerge` depends on this package to work, and it should be installed alongside it. [More info on the difference between `dependencies` and `devDependencies`](https://stackoverflow.com/a/22004559)