### PR TITLE
Add TypeScript definitions and test

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+declare function deepmerge<T>(x: Partial<T>, y: Partial<T>, options?: deepmerge.Options): T;
+declare function deepmerge<T1, T2>(x: Partial<T1>, y: Partial<T2>, options?: deepmerge.Options): T1 & T2;
+
+declare namespace deepmerge {
+	export interface Options {
+		arrayMerge?(target: any[], source: any[], options?: Options): any[];
+		clone?: boolean;
+		isMergeableObject?(value: object): boolean;
+	}
+
+	export function all (objects: object[], options?: Options): object;
+}
+
+export default deepmerge;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2892,6 +2892,12 @@
         "prelude-ls": "1.1.2"
       }
     },
+    "typescript": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz",
+      "integrity": "sha1-YGAiUIR5tV/6NotY/uljoD39eww=",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.12.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2893,9 +2893,9 @@
       }
     },
     "typescript": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz",
-      "integrity": "sha1-YGAiUIR5tV/6NotY/uljoD39eww=",
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.0.0.tgz",
+      "integrity": "sha1-FHlfnDngYCJZeioJ63M62r75sIw=",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2893,9 +2893,9 @@
       }
     },
     "typescript": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.0.0.tgz",
-      "integrity": "sha1-FHlfnDngYCJZeioJ63M62r75sIw=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz",
+      "integrity": "sha1-YGAiUIR5tV/6NotY/uljoD39eww=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "test": "npm run build && tap test/*.js && jsmd readme.md && npm run test:typescript",
-    "test:typescript": "node ./node_modules/typescript/lib/tsc.js --noEmit test/typescript.ts",
+    "test": "npm run build && tap test/*.js && jsmd readme.md && tsc --noEmit test/typescript.ts",
     "size": "npm run build && uglifyjs --compress --mangle -- ./dist/umd.js | gzip -c | wc -c"
   },
   "devDependencies": {
@@ -35,7 +34,7 @@
     "rollup-plugin-commonjs": "8.2.1",
     "rollup-plugin-node-resolve": "3.0.0",
     "tap": "~7.1.2",
-    "typescript": ">=2.2.2",
+    "typescript": ">=2.0.0",
     "uglify-js": "^3.3.12"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rollup-plugin-commonjs": "8.2.1",
     "rollup-plugin-node-resolve": "3.0.0",
     "tap": "~7.1.2",
-    "typescript": ">=2.0.0",
+    "typescript": "2.0.0",
     "uglify-js": "^3.3.12"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "test": "npm run build && tap test/*.js && jsmd readme.md",
+    "test": "npm run build && tap test/*.js && jsmd readme.md && npm run test:typescript",
+    "test:typescript": "node ./node_modules/typescript/lib/tsc.js --noEmit test/typescript.ts",
     "size": "npm run build && uglifyjs --compress --mangle -- ./dist/umd.js | gzip -c | wc -c"
   },
   "devDependencies": {
@@ -34,6 +35,7 @@
     "rollup-plugin-commonjs": "8.2.1",
     "rollup-plugin-node-resolve": "3.0.0",
     "tap": "~7.1.2",
+    "typescript": ">=2.2.2",
     "uglify-js": "^3.3.12"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rollup-plugin-commonjs": "8.2.1",
     "rollup-plugin-node-resolve": "3.0.0",
     "tap": "~7.1.2",
-    "typescript": "2.0.0",
+    "typescript": "=2.2.2",
     "uglify-js": "^3.3.12"
   },
   "license": "MIT"

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,0 +1,50 @@
+import merge from '../';
+
+const x = {
+	foo: 'abc',
+	bar: 'def',
+}
+
+const y = {
+	foo: 'cba',
+	bar: 'fed',
+}
+
+const z = {
+	baz: '123',
+	quux: '456',
+}
+
+let merged1 = merge(x, y);
+let merged2 = merge(x, z);
+let merged3 = merge.all([ x, y, z ]);
+
+merged1.foo;
+merged1.bar;
+merged2.foo;
+merged2.baz;
+
+const options1: merge.Options = {
+	clone: true,
+	isMergeableObject (obj) {
+		return true;
+	},
+};
+
+const options2: merge.Options = {
+	arrayMerge (target, source, options) {
+		target.length;
+		source.length;
+		options.isMergeableObject(target);
+
+		return [];
+	},
+	clone: true,
+	isMergeableObject (obj) {
+		return true;
+	},
+};
+
+merged1 = merge(x, y, options1);
+merged2 = merge(x, z, options2);
+merged3 = merge([x, y, z], options1);


### PR DESCRIPTION
This PR adds working TypeScript definitions (the [DefinitelyTyped ones](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/deepmerge/index.d.ts) don't work). JavaScript projects can take two approaches to providing TS definitions:

* provide them with the npm package
* provide them in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/)

The second approach is [recommended](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) by the TypeScript project. For projects that are willing to take on the maintenance of typedefs the first approach seems preferable to me. For projects that would rather focus strictly on JS and let the TS community handle typedefs, the second is clearly preferable.

@TehShrike [indicated interest](https://github.com/KyleAMathews/deepmerge/issues/87#issuecomment-425438300) in maintaining typedefs within the deepmerge project, so I am submitting this PR.

* `index.d.ts`: add typedefs
* `package.json`
    * add `typescript` as dev dependency. Why `>=2.2.2`?
        * TS 2 is 2 years old
        * 2.0.2 is the first non-prelease V2 tag
        * `npm install typescript@2.0.2` results in 2.2.2
        * 3.1.1 is current; I have tested with 2.2.2 and 3.0.3
    * add script: `test:typescript`; also added it to the `test` script
    * the TS test invokes `tsc.js` directly since `typescript/bin/tsc` will not run on Windows
* `tests/typescript.ts`: this file contains non-functional code that simply exercises the typedefs. If it compiles without error then the typedefs are not terribly broken (they could still be too loose, e.g. I don't think it's possible to specify a concrete type for the union of an arbitrary number of objects for `merge.all`, but I am not a TS master).