### PR TITLE
allow for `require('deepmerge').default` as a workaround for Webpack builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,3 +62,4 @@ deepmerge.all = function deepmergeAll(array, options) {
 }
 
 module.exports = deepmerge
+module.exports.default = deepmerge // require('deepmerge').default will fix bundle problems with Webpack


### PR DESCRIPTION
This will make deepmerge work when Webpack builds are supported. It’s an alternative solution to removing the es build altogether (https://github.com/KyleAMathews/deepmerge/pull/124)